### PR TITLE
TUG-50 adapt sensor configuration

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,9 +7,8 @@
     state: present
 
 - name: Configure Falcon Sensor Options
-  command:  "/opt/CrowdStrike/falconctl -s --cid={{ falcon_customer_id }} --provisioning-token={{ falcon_provisioning_token }}"
+  command: "/opt/CrowdStrike/falconctl -s -f --cid={{ falcon_customer_id }} --provisioning-token={{ falcon_provisioning_token }}"
   become: true
-  changed_when: false
   ignore_errors: true
   notify: Restart Falcon Sensor
 


### PR DESCRIPTION
This change is needed to be able to install the sensor on mutable instances. 
It's been tested in several instances with different Ubuntu versions and it works with no issue. 

Also, all mutable instances are now working with this change applied