### PR TITLE
SECOPS-347: Get latest falcon binary from Download list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [v1.0.3](https://github.com/StuartApp/ansible-falcon/releases/tag/1.0.3) (Feb 22, 2023)
+
+- Download latest binary before installing.
+
 ## [v1.0.2](https://github.com/StuartApp/ansible-falcon/releases/tag/1.0.2) (Aug 24, 2022)
 
 - Add changelog and codeowners, fix a typo.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Role Name
 =========
-The purpose of this role is to download, install and configure CrowdStrike Falcon sensor it on our EC2 instances. The sensor must be downloaded from Crowdstrike Cloud using MFA. 
+
+The purpose of this role is to download, install and configure CrowdStrike Falcon sensor it on our EC2 instances. The sensor must be downloaded from Crowdstrike Cloud using MFA.
 
 In the first step, we will connect to the mentionced cloud environment to obtain a `Bearer token` which will be used to download the `pkg`. The distribution used is compatible with Ubuntu 16/18 and 20.
 
 After downloading and installing the `pkg` - the `falcon-sensor` must be configured. According to the official documentation both the Customer ID (CID) and `provisioning-token` must be provided.
-
 
 Requirements
 ------------
@@ -18,7 +18,6 @@ Role Variables and Secrets
 Supported variables:
 
 * `falcon_cloud` - CrowdStrike API URL for downloading the Falcon sensor.
-* `falcon_installer_id` - Installer ID: default version to be installed
 * `falcon_install_tmp_dir` - Where should the sensor file be downloaded to on Linux
 
 Supported secrets:
@@ -32,6 +31,7 @@ This information can be found on under Falcon UI and won't be changed in the nea
 
 Dependencies
 ------------
+
 No dependencies
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 falcon_cloud: "api.eu-1.crowdstrike.com"
-falcon_installer_id: "816f619e3ca536dd890926b0d619ea070771548d4ab3d2b66049809d2457dd1e"
 falcon_install_tmp_dir: "/tmp"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,9 @@
 ---
 falcon_cloud: "api.eu-1.crowdstrike.com"
 falcon_install_tmp_dir: "/tmp"
+falcon_os_arch_dict:
+  # exclude arm64 and s390x
+  x86_64: '"+os_version:!~"arm64"+os_version:!~"zLinux"'
+  aarch64: '"+os_version:~"arm64"'
+  s390x: '"+os_version:~"zLinux"'
+falcon_sensor_version_decrement: 0 # latest

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -36,14 +36,14 @@
     falcon_sensor_update_policy_platform: "{{ ansible_facts['system'] }}"
     falcon_os_vendor: "{{ ansible_facts['os_family'] | lower if (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Amazon') else ansible_facts['distribution'] | lower }}"
 
+- name: "Determine Operating System Architecture (Linux)"
+  set_fact:
+    falcon_os_arch: "{{ falcon_os_arch_dict[ansible_facts['architecture']] }}"
+  when: ansible_facts['system'] == "Linux"
+
 - name: "Build API Sensor Query"
   set_fact:
-    falcon_os_query:
-      '{{ ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch + ''+version:"'' + falcon_sensor_version + ''"''
-      if (falcon_sensor_version) else ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch }}'
-
-- debug:
-    msg: falcon_target_os {{ falcon_target_os }}, falcon_os_query {{ falcon_os_query }}
+    falcon_os_query: '{{ ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch }}'
 
 - name: Get list of filtered Falcon sensors
   uri:
@@ -56,7 +56,7 @@
   register: falcon_api_installer_list
   no_log: true
 
-- name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
+- name: Download Falcon Sensor Installation Package
   get_url:
     url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].sha256 }}"
     dest: "{{ falcon_install_temp_directory.path }}"
@@ -66,7 +66,6 @@
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false
   register: falcon_sensor_download
-  no_log: true
 
 - name: Set full file download path
   set_fact:

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -42,7 +42,7 @@
       '{{ ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch + ''+version:"'' + falcon_sensor_version + ''"''
       if (falcon_sensor_version) else ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch }}'
 
-  ansible.builtin.debug:
+- debug:
     msg: falcon_target_os {{ falcon_target_os }}, falcon_os_query {{ falcon_os_query }}
 
 - name: Get list of filtered Falcon sensors

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -28,10 +28,37 @@
   register: falcon_api_oauth2_token
   no_log: true
 
-- name: Download Falcon Sensor Installation Package
+- name: "Default Operating System configuration"
+  set_fact:
+    falcon_target_os: "{{ ansible_facts['distribution'] }}"
+    falcon_os_family: "{{ ansible_facts['system'] | lower }}"
+    falcon_os_version: "*{{ ansible_facts['distribution_major_version'] }}*"
+    falcon_sensor_update_policy_platform: "{{ ansible_facts['system'] }}"
+    falcon_os_vendor: "{{ ansible_facts['os_family'] | lower if (ansible_facts['os_family'] == 'RedHat' and ansible_facts['distribution'] != 'Amazon') else ansible_facts['distribution'] | lower }}"
+
+- name: "Build API Sensor Query"
+  set_fact:
+    falcon_os_query:
+      '{{ ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch + ''+version:"'' + falcon_sensor_version + ''"''
+      if (falcon_sensor_version) else ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch }}'
+
+- name: Get list of filtered Falcon sensors
+  uri:
+    url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"
+    method: GET
+    return_content: true
+    headers:
+      authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
+      Content-Type: application/json
+  register: falcon_api_installer_list
+  no_log: true
+
+- name: CrowdStrike Falcon | Download Falcon Sensor Installation Package
   get_url:
-    url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_installer_id }}"
+    url: "https://{{ falcon_cloud }}/sensors/entities/download-installer/v1?id={{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].sha256 }}"
     dest: "{{ falcon_install_temp_directory.path }}"
+    checksum: "sha256:{{ falcon_api_installer_list.json.resources[falcon_sensor_version_decrement | int].sha256 }}"
+    mode: 0640
     headers:
       authorization: "Bearer {{ falcon_api_oauth2_token.json.access_token }}"
   changed_when: false

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -42,6 +42,9 @@
       '{{ ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch + ''+version:"'' + falcon_sensor_version + ''"''
       if (falcon_sensor_version) else ''os:"'' + falcon_target_os + ''"+os_version:"'' + falcon_os_version + falcon_os_arch }}'
 
+  ansible.builtin.debug:
+    msg: falcon_target_os {{ falcon_target_os }}, falcon_os_query {{ falcon_os_query }}
+
 - name: Get list of filtered Falcon sensors
   uri:
     url: "https://{{ falcon_cloud }}/sensors/combined/installers/v1?filter={{ falcon_os_query | urlencode }}"


### PR DESCRIPTION
So we:
* are always running the latest falcon/crowdstrike binaries in our infra
* don't encounter failures in the Immutable Base AMI jobs like this morning.

Tested for x86_64 archs